### PR TITLE
Updating the documentation to use op

### DIFF
--- a/docs/resources/quality_gate.md
+++ b/docs/resources/quality_gate.md
@@ -21,13 +21,13 @@ resource "sonarcloud_quality_gate" "awesome" {
     {
       metric = "coverage"
       error  = 100
-      Op     = "LT"
+      op     = "LT"
     },
     // Less than 100% coverage on new code
     {
       metric = "new_coverage"
       error  = 100
-      Op     = "LT"
+      op     = "LT"
     }
   ]
 


### PR DESCRIPTION
Updated the documentation to use op instead of Op, so that it is now a properly working example for the sonarcloud_quality_gate