### PR TITLE
Bump go-sonarcloud package version and fix #139 issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	github.com/reinoudk/go-sonarcloud v0.3.1
+	github.com/reinoudk/go-sonarcloud v0.3.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/reinoudk/go-sonarcloud v0.3.1 h1:B2rBAZmMnQKj3Go4dLqCFM4Lt576Ujxkrbat4vVX5Aw=
 github.com/reinoudk/go-sonarcloud v0.3.1/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
+github.com/reinoudk/go-sonarcloud v0.3.2 h1:3oFuyCp7TcAlImRudJ4uhNk3lyVqzWqtoU8jI6RBR3c=
+github.com/reinoudk/go-sonarcloud v0.3.2/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=


### PR DESCRIPTION
Bump github.com/reinoudk/go-sonarcloud from v0.3.1 to v0.3.2 in order to fix https://github.com/rewe-digital/terraform-provider-sonarcloud/issues/139